### PR TITLE
Update compose.base.yml to use environment variables for networks aliases

### DIFF
--- a/compose.base.yml
+++ b/compose.base.yml
@@ -84,7 +84,7 @@ services:
     networks:
       openuem:
         aliases:
-          - ocsp.openuem.example
+          - ${OCSP_HOST}
 
   nats-server:
     container_name: openuem-nats-server
@@ -118,7 +118,7 @@ services:
     networks:
       openuem:
         aliases:
-          - nats.openuem.example
+          - ${NATS_HOST}
 
 
   notification-worker:
@@ -234,7 +234,7 @@ services:
     networks:
       openuem:
         aliases:
-          - console.openuem.example
+          - ${CONSOLE_HOST}
 
 networks:
   openuem:


### PR DESCRIPTION
There are already environment variables for OCSP_HOST, NATS_HOST, and CONSOLE_HOST in the .env file, so this changes compose.base.yml to use those environment variables for the networks aliases of the ocsp-responder, nats-server, and console services. This allows users to customize the domains in the .env file without also needing to update the compose file.